### PR TITLE
chore: remove error.code in error middleware (#20)

### DIFF
--- a/backend/src/controllers/notesController.js
+++ b/backend/src/controllers/notesController.js
@@ -4,7 +4,6 @@ const notFoundError = (data, message) => {
   if (!data) {
     const error = new Error(message);
     error.statusCode = 404;
-    error.code = "DATA_NOT_FOUND";
     throw error;
   }
 };

--- a/backend/src/middlewares/errorMiddleware.js
+++ b/backend/src/middlewares/errorMiddleware.js
@@ -4,13 +4,12 @@ const errorMiddleware = (err, req, res, next) => {
 
     const success = false;
     let statusCode = err.statusCode || 500;
-    let code = err.code || "SERVER_ERROR";
+
     let message = err.message || "Internal server error";
 
     res.status(statusCode).json({
       error: {
         success,
-        code,
         message,
       },
     });


### PR DESCRIPTION
Fixes #20. Removed `error.code` from `errorMiddleware.js` and `notesController.js` as requested. @SirGhaniR